### PR TITLE
Do you want magick?

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Encoding: UTF-8
 LazyData: true
 License: CC BY 4.0 + file LICENSE
 RoxygenNote: 7.1.0
-Suggests: knitr, rmarkdown, BiocStyle
+Suggests: knitr, rmarkdown, BiocStyle, magick
 Imports: PharmacoGx, RadioGx, SummarizedExperiment, ToxicoGx, ggplot2, Xeva, igraph, pkgdown
 URL:  https://bhklab.github.io/bioc2020workshop
 BugReports: https://github.com/bhklab/bioc2020workshop/issues/new/choose


### PR DESCRIPTION
I see a lot of notes like this when building the vignette. It's not an error, but just FYI in case your vignette would display better with magick. For example:

```
Summarizing rna molecular data for:	CCLE
The magick package is required to crop "/home/rstudio/vignettes/GxWorkshop_files/figure-html/ccleaac-1.png" but not available.
```